### PR TITLE
Add conditional comment for internet explorer 9 elementor popup compatibility

### DIFF
--- a/src/header.php
+++ b/src/header.php
@@ -12,6 +12,13 @@
         window.location = "http://whatbrowser.org/intl/de/";
     </script>
     <![endif]-->
+
+    <!--[if IE 9]>
+    <style>
+        .elementor-popup-modal { display: block !important; }
+        .elementor-popup-modal > div { left: 50%; transform: translateX(-50%); }
+    </style>
+    <![endif]-->
 </head>
 <body <?php body_class( 'no-js' ); ?>>
 <script>


### PR DESCRIPTION
Because elementor uses flexbox for their popups we need a conditional comment for internet explorer 9 to use them.

